### PR TITLE
feat: expose endpoint_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ No modules.
 | <a name="input_alt_names"></a> [alt\_names](#input\_alt\_names) | Optional, Alternate names for the certificate to be created | `list(string)` | `null` | no |
 | <a name="input_certificate_template_name"></a> [certificate\_template\_name](#input\_certificate\_template\_name) | Name of the Certificate Template to create for a private\_cert secret engine | `string` | n/a | yes |
 | <a name="input_country"></a> [country](#input\_country) | Optional, Country (C) values to define in the subject field of the resulting certificate | `list(string)` | `null` | no |
+| <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | The endpoint type to communicate with the provided secrets manager instance. Possible values are `public` or `private` | `string` | `"public"` | no |
 | <a name="input_exclude_cn_from_sans"></a> [exclude\_cn\_from\_sans](#input\_exclude\_cn\_from\_sans) | Optional, Set whether the common name is excluded from Subject Alternative Names (SANs). If set to true, the common name is not included in DNS or Email SANs if they apply | `bool` | `false` | no |
 | <a name="input_intermediate_ca_common_name"></a> [intermediate\_ca\_common\_name](#input\_intermediate\_ca\_common\_name) | Common name for the intermediate CA | `string` | `"cloud.ibm.com"` | no |
 | <a name="input_intermediate_ca_crl_disable"></a> [intermediate\_ca\_crl\_disable](#input\_intermediate\_ca\_crl\_disable) | crl\_disable for the intermediate CA | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@
 resource "ibm_sm_private_certificate_configuration_root_ca" "private_certificate_root_ca" {
   instance_id                       = var.secrets_manager_guid
   region                            = var.region
+  endpoint_type                     = var.endpoint_type
   name                              = var.root_ca_name
   common_name                       = var.root_ca_common_name
   max_ttl                           = var.root_ca_max_ttl
@@ -34,6 +35,7 @@ resource "ibm_sm_private_certificate_configuration_root_ca" "private_certificate
 resource "ibm_sm_private_certificate_configuration_intermediate_ca" "intermediate_ca" {
   instance_id                       = var.secrets_manager_guid
   name                              = var.intermediate_ca_name
+  endpoint_type                     = var.endpoint_type
   common_name                       = var.intermediate_ca_common_name
   signing_method                    = var.intermediate_ca_signing_method
   issuer                            = var.root_ca_name
@@ -69,6 +71,7 @@ resource "ibm_sm_private_certificate_configuration_template" "certificate_templa
   instance_id                        = var.secrets_manager_guid
   region                             = var.region
   name                               = var.certificate_template_name
+  endpoint_type                      = var.endpoint_type
   certificate_authority              = var.intermediate_ca_name
   max_ttl                            = var.template_max_ttl
   allow_any_name                     = var.template_allow_any_name

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,16 @@ variable "region" {
   description = "Region of the secrets manager instance"
 }
 
+variable "endpoint_type" {
+  type        = string
+  description = "The endpoint type to communicate with the provided secrets manager instance. Possible values are `public` or `private`"
+  default     = "public"
+  validation {
+    condition     = contains(["public", "private"], var.endpoint_type)
+    error_message = "The specified endpoint_type is not a valid selection!"
+  }
+}
+
 variable "organizational_unit" {
   type        = list(string)
   description = "Optional, Organizational Unit (OU) values to define in the subject field of the resulting certificate"


### PR DESCRIPTION
### Description
Exposed endpoint_type to allow for private secret manager. 

Related issue: https://github.com/terraform-ibm-modules/terraform-ibm-secrets-manager-private-cert-engine/issues/182

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
