### PR TITLE
refactor: cross object reference for input variable validation and version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You need the following permissions to run this module.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.76.0, < 2.0.0 |
 
 ### Modules

--- a/examples/default/version.tf
+++ b/examples/default/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= v1.3.0"
+  required_version = ">= v1.9.0"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/examples/private/version.tf
+++ b/examples/private/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= v1.3.0"
+  required_version = ">= v1.9.0"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/main.tf
+++ b/main.tf
@@ -2,17 +2,6 @@
 # Secrets Manager Private Secrets Engine Module
 ##############################################################################
 
-# Validation
-# approach based on https://stackoverflow.com/a/66682419
-locals {
-  # intermediate CA common name and root CA common name are different
-  common_name_validate_condition = var.root_ca_common_name == var.intermediate_ca_common_name
-  common_name_validate_msg       = "The values for 'root_ca_common_name' and 'intermediate_ca_common_name' must be different"
-  # tflint-ignore: terraform_unused_declarations
-  common_name_validate_check = regex("^${local.common_name_validate_msg}$", (!local.common_name_validate_condition ? local.common_name_validate_msg : ""))
-
-}
-
 resource "ibm_sm_private_certificate_configuration_root_ca" "private_certificate_root_ca" {
   instance_id                       = var.secrets_manager_guid
   region                            = var.region

--- a/variables.tf
+++ b/variables.tf
@@ -305,6 +305,11 @@ variable "root_ca_common_name" {
     condition     = can(regex("(.*?)", var.root_ca_common_name))
     error_message = "root_ca_common_name must match regular expression /(.*?)/"
   }
+
+  validation {
+    condition     = var.root_ca_common_name != var.intermediate_ca_common_name
+    error_message = "The values for 'root_ca_common_name' and 'intermediate_ca_common_name' must be different."
+  }
 }
 
 variable "root_ca_crl_expiry" {

--- a/version.tf
+++ b/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
   required_providers {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {


### PR DESCRIPTION
### Description

Used cross-object referencing for input variable validation and updated required terraform version to >= 1.9.0.
[Git _issue](https://github.ibm.com/GoldenEye/issues/issues/13252)
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Used cross-object referencing for input variable validation and updated required terraform version to >= 1.9.0.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
