### PR TITLE
chore: update sm_tags to resource_tags and secrets_manager module to 2.15.0

### DIFF
--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -8,13 +8,13 @@ module "resource_group" {
 
 module "secrets_manager" {
   source               = "terraform-ibm-modules/secrets-manager/ibm"
-  version              = "2.14.2"
+  version              = "2.15.0"
   resource_group_id    = module.resource_group.resource_group_id
   region               = var.region
   secrets_manager_name = "${var.prefix}-secrets-manager"
   sm_service_plan      = "trial"
   allowed_network      = "public-and-private"
-  sm_tags              = var.resource_tags
+  resource_tags        = var.resource_tags
 }
 
 module "private_secret_engine" {

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -8,14 +8,14 @@ module "resource_group" {
 
 module "secrets_manager" {
   source               = "terraform-ibm-modules/secrets-manager/ibm"
-  version              = "2.14.2"
+  version              = "2.15.0"
   resource_group_id    = module.resource_group.resource_group_id
   region               = var.region
   secrets_manager_name = "${var.prefix}-secrets-manager"
   sm_service_plan      = "trial"
   allowed_network      = "private-only"
   endpoint_type        = "private"
-  sm_tags              = var.resource_tags
+  resource_tags        = var.resource_tags
 }
 
 module "private_secret_engine" {


### PR DESCRIPTION
### Description
The latest release [2.15.0](https://github.com/terraform-ibm-modules/terraform-ibm-secrets-manager/releases/tag/v2.15.0) of terraform-ibm-secrets-manager updates `sm_tags` to `resource_tags`. This PR updates the secrets_manager module version to 2.15.0 and updates all instances of `sm_tags` to `resource_tags` to maintain compatibility.

### Release required?

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

### Changes
- Updated terraform-ibm-secrets-manager module version to 2.15.0
- Replaced all instances of `sm_tags` with `resource_tags`

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
